### PR TITLE
Fixes #12: States including css are now used

### DIFF
--- a/ui-route-styles.js
+++ b/ui-route-styles.js
@@ -17,8 +17,15 @@
 					elem.append($compile(html)(scope));
 					scope.routeStyles = {};
 					$rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
-						
 						// Remove old styles
+						if (fromState && fromState.css) {
+							if(!Array.isArray(fromState.css)){
+								fromState.css = [fromState.css];
+							}
+							angular.forEach(fromState.css, function(sheet){
+								delete scope.routeStyles[sheet];
+							});
+						}
 						if(fromState && fromState.views){
 							angular.forEach(fromState.views, function(view){
 								if(view.css){
@@ -44,6 +51,14 @@
 									});
 									
 								}
+							});
+						}
+						if (toState && toState.css) {
+							if(!Array.isArray(toState.css)){
+								toState.css = [toState.css];
+							}
+							angular.forEach(toState.css, function(sheet){
+								scope.routeStyles[sheet] = sheet;
 							});
 						}
 					});

--- a/ui-route-styles.js
+++ b/ui-route-styles.js
@@ -19,7 +19,7 @@
 					$rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
 						// Remove old styles
 						if (fromState && fromState.css) {
-							if(!Array.isArray(fromState.css)){
+							if(!angular.isArray(fromState.css)){
 								fromState.css = [fromState.css];
 							}
 							angular.forEach(fromState.css, function(sheet){
@@ -29,7 +29,7 @@
 						if(fromState && fromState.views){
 							angular.forEach(fromState.views, function(view){
 								if(view.css){
-									if(!Array.isArray(view.css)){
+									if(!angular.isArray(view.css)){
 										view.css = [view.css];
 									}
 									angular.forEach(view.css, function(sheet){
@@ -43,7 +43,7 @@
 						if(toState && toState.views){
 							angular.forEach(toState.views, function(view){
 								if(view.css){
-									if(!Array.isArray(view.css)){
+									if(!angular.isArray(view.css)){
 										view.css = [view.css];
 									}
 									angular.forEach(view.css, function(sheet){
@@ -54,7 +54,7 @@
 							});
 						}
 						if (toState && toState.css) {
-							if(!Array.isArray(toState.css)){
+							if(!angular.isArray(toState.css)){
 								toState.css = [toState.css];
 							}
 							angular.forEach(toState.css, function(sheet){


### PR DESCRIPTION
This fix allows to use the ````css```` attribute inside the state instead of declaring it inside ````views````